### PR TITLE
free_splitのNULL修正

### DIFF
--- a/includes/cub3d.h
+++ b/includes/cub3d.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   cub3d.h                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ryabuki <ryabuki@student.42.fr>            +#+  +:+       +#+        */
+/*   By: myokono <myokono@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/23 10:37:41 by myokono           #+#    #+#             */
-/*   Updated: 2025/05/01 12:52:07 by ryabuki          ###   ########.fr       */
+/*   Updated: 2025/05/01 12:58:02 by myokono          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -185,7 +185,7 @@ void	free_textures(t_game *game);
 
 /* utils */
 bool	error_msg(char *msg);
-void	free_split(char **split);
+void	free_split(char ***split);
 int		rgb_to_int(int r, int g, int b);
 int		get_next_line(int fd, char **line);
 bool	is_valid_extension(char *filename, char *ext);

--- a/srcs/parser/config_parser.c
+++ b/srcs/parser/config_parser.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   config_parser.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ryabuki <ryabuki@student.42.fr>            +#+  +:+       +#+        */
+/*   By: myokono <myokono@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/23 10:39:37 by myokono           #+#    #+#             */
-/*   Updated: 2025/05/01 12:52:22 by ryabuki          ###   ########.fr       */
+/*   Updated: 2025/05/01 12:58:38 by myokono          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,17 +43,17 @@ static bool	parse_color(t_game *game, char *line, char type)
 	if (rgb == NULL)
 		return (error_msg(ERR_MEMORY));
 	if (!rgb[0] || !rgb[1] || !rgb[2] || rgb[3])
-		return (free_split(rgb), error_msg(ERR_CONFIG));
+		return (free_split(&rgb), error_msg(ERR_CONFIG));
 	r = ft_atoi(rgb[0]);
 	g = ft_atoi(rgb[1]);
 	b = ft_atoi(rgb[2]);
 	if (r < 0 || r > 255 || g < 0 || g > 255 || b < 0 || b > 255)
-		return (free_split(rgb), error_msg(ERR_CONFIG));
+		return (free_split(&rgb), error_msg(ERR_CONFIG));
 	if (type == 'F')
 		game->floor_color = rgb_to_int(r, g, b);
 	else if (type == 'C')
 		game->ceiling_color = rgb_to_int(r, g, b);
-	free_split(rgb);
+	free_split(&rgb);
 	return (true);
 }
 

--- a/srcs/utils/cleanup.c
+++ b/srcs/utils/cleanup.c
@@ -6,7 +6,7 @@
 /*   By: myokono <myokono@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/23 10:51:28 by myokono           #+#    #+#             */
-/*   Updated: 2025/04/27 19:39:59 by myokono          ###   ########.fr       */
+/*   Updated: 2025/05/01 12:57:27 by myokono          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -76,18 +76,20 @@ void	cleanup_game(t_game *game)
 	}
 }
 
-void	free_split(char **split)
+void	free_split(char ***split)
 {
-	int	i;
+	int		i;
+	char	**tmp;
 
-	if (!split)
+	if (!split || !*split)
 		return ;
+	tmp = *split;
 	i = 0;
-	while (split[i])
+	while (tmp[i])
 	{
-		free(split[i]);
-		split[i] = NULL;
+		free(tmp[i]);
 		i++;
 	}
-	free(split);
+	free(tmp);
+	*split = NULL;
 }


### PR DESCRIPTION
This pull request introduces changes to improve memory management and update author information in the `cub3d` project. The most significant updates include modifying the `free_split` function to handle a double pointer for safer memory deallocation and updating author metadata in relevant files.

### Memory Management Improvements:
* Updated `free_split` function in `srcs/utils/cleanup.c` to accept a triple pointer (`char ***split`) for safer memory deallocation. This ensures the caller's pointer is set to `NULL` after freeing memory.
* Updated calls to `free_split` in `srcs/parser/config_parser.c` to pass a double pointer (`&rgb`) in accordance with the new `free_split` signature.
* Updated the declaration of `free_split` in `includes/cub3d.h` to match the new function signature.

### Author Information Updates:
* Updated author metadata in the headers of `includes/cub3d.h`, `srcs/parser/config_parser.c`, and `srcs/utils/cleanup.c` to reflect the new author `myokono`. [[1]](diffhunk://#diff-969dbb539a259f4b8110cd99e37bdc5d7835ac65056edf55f8c55c98bbe53e86L6-R9) [[2]](diffhunk://#diff-aa5807d987ec8194dfe17241e90e7953c5e23eed05cd7c7e38049c1a281532c9L6-R9) [[3]](diffhunk://#diff-0f805960495c64ef6a6be4686a76ccb6b76251aa862e35881793a10597133839L9-R9)