### PR TITLE
25行以内になるようにread_line_maps functionを分割しました

### DIFF
--- a/srcs/parser/map_parser.c
+++ b/srcs/parser/map_parser.c
@@ -6,7 +6,7 @@
 /*   By: ryabuki <ryabuki@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/23 10:39:02 by myokono           #+#    #+#             */
-/*   Updated: 2025/05/01 12:59:00 by ryabuki          ###   ########.fr       */
+/*   Updated: 2025/05/01 13:15:16 by ryabuki          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,11 +27,30 @@ static void	free_map_lines(char **lines, int height)
 	free(lines);
 }
 
+static int	ft_helper(char *line, char ***map_lines, int *height)
+{
+	int		i;
+	char	**new_map_lines;
+
+	new_map_lines = malloc(sizeof(char *) * (*height + 2));
+	if (!new_map_lines)
+		return (free(line), error_msg(ERR_MEMORY));
+	i = 0;
+	while (i < *height)
+	{
+		new_map_lines[i] = (*map_lines)[i];
+		i++;
+	}
+	new_map_lines[*height] = line;
+	new_map_lines[*height + 1] = NULL;
+	free(*map_lines);
+	*map_lines = new_map_lines;
+	return (true);
+}
+
 static int	read_map_lines(int fd, char ***map_lines, int *height)
 {
 	char	*line;
-	char	**new_map_lines;
-	int		i;
 
 	*map_lines = NULL;
 	*height = 0;
@@ -43,19 +62,8 @@ static int	read_map_lines(int fd, char ***map_lines, int *height)
 			free(line);
 			continue ;
 		}
-		new_map_lines = malloc(sizeof(char *) * (*height + 2));
-		if (!new_map_lines)
-			return (free(line), error_msg(ERR_MEMORY));
-		i = 0;
-		while (i < *height)
-		{
-			new_map_lines[i] = (*map_lines)[i];
-			i++;
-		}
-		new_map_lines[*height] = line;
-		new_map_lines[*height + 1] = NULL;
-		free(*map_lines);
-		*map_lines = new_map_lines;
+		if (ft_helper(line, map_lines, height) == false)
+			return (false);
 		(*height)++;
 	}
 	free(line);


### PR DESCRIPTION
This pull request refactors the `read_map_lines` function in `srcs/parser/map_parser.c` to improve code readability and modularity by introducing a helper function. Additionally, it includes a minor update to the file's metadata comment.

### Refactoring for readability and modularity:

* Extracted part of the logic from `read_map_lines` into a new helper function `ft_helper` to handle memory allocation and error checking for map lines. This change improves the clarity and maintainability of the code. (`srcs/parser/map_parser.c`, [[1]](diffhunk://#diff-2b39a6ea9a17f277e0d7265ca18b7b91e8414776ce1b4d82d73b1d9132200bc7L30-L45) [[2]](diffhunk://#diff-2b39a6ea9a17f277e0d7265ca18b7b91e8414776ce1b4d82d73b1d9132200bc7R48-R66)

### Metadata update:

* Updated the timestamp in the file header comment to reflect the latest modification time. (`srcs/parser/map_parser.c`, [srcs/parser/map_parser.cL9-R9](diffhunk://#diff-2b39a6ea9a17f277e0d7265ca18b7b91e8414776ce1b4d82d73b1d9132200bc7L9-R9))